### PR TITLE
🐑 Removes __future__ annotations import

### DIFF
--- a/anvil/region.py
+++ b/anvil/region.py
@@ -1,9 +1,13 @@
-from __future__ import annotations
 from typing import Tuple, Union, BinaryIO
 from nbt import nbt
 import zlib
 from io import BytesIO
 import anvil
+
+MYPY = False
+if MYPY:
+    from .chunk import Chunk
+
 
 class Region:
     """

--- a/anvil/region.py
+++ b/anvil/region.py
@@ -97,16 +97,16 @@ class Region:
         return anvil.Chunk.from_region(self, chunk_x, chunk_z)
 
     @classmethod
-    def from_file(cls, file: Union[str, BinaryIO]):
+    def from_file(cls, file: Union[str, BinaryIO]) -> 'Region':
         """
         Creates a new region with the data from reading the given file
-        
+
         Parameters
         ----------
         file
             Either a file path or a file object
         """
-        if type(file == str):
+        if isinstance(file, str):
             with open(file, 'rb') as f:
                 return cls(data=f.read())
         else:

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,0 +1,27 @@
+import context as _
+
+import io
+import secrets
+
+import pytest
+
+from anvil import Region
+
+
+def test_from_filename(tmp_path):
+    filename = tmp_path / "r.?.?.mca"
+    contents = secrets.token_bytes()
+
+    with open(filename, 'wb') as f:
+        f.write(contents)
+
+    region = Region.from_file(str(filename))
+    assert region.data == contents
+
+
+def test_from_filelike():
+    contents = secrets.token_bytes()
+    filelike = io.BytesIO(contents)
+
+    region = Region.from_file(filelike)
+    assert region.data == contents


### PR DESCRIPTION
This `__future__` import renders the library unusable by anything lower
than Python 3.7, and the rest of the file still uses strings for
specification of types, so it's not required.