### PR TITLE
🐛 Fixes reading regions from filelike objects

### DIFF
--- a/anvil/region.py
+++ b/anvil/region.py
@@ -93,16 +93,16 @@ class Region:
         return anvil.Chunk.from_region(self, chunk_x, chunk_z)
 
     @classmethod
-    def from_file(cls, file: Union[str, BinaryIO]):
+    def from_file(cls, file: Union[str, BinaryIO]) -> 'Region':
         """
         Creates a new region with the data from reading the given file
-        
+
         Parameters
         ----------
         file
             Either a file path or a file object
         """
-        if type(file == str):
+        if isinstance(file, str):
             with open(file, 'rb') as f:
                 return cls(data=f.read())
         else:

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,0 +1,27 @@
+import context as _
+
+import io
+import secrets
+
+import pytest
+
+from anvil import Region
+
+
+def test_from_filename(tmp_path):
+    filename = tmp_path / "r.?.?.mca"
+    contents = secrets.token_bytes()
+
+    with open(filename, 'wb') as f:
+        f.write(contents)
+
+    region = Region.from_file(str(filename))
+    assert region.data == contents
+
+
+def test_from_filelike():
+    contents = secrets.token_bytes()
+    filelike = io.BytesIO(contents)
+
+    region = Region.from_file(filelike)
+    assert region.data == contents


### PR DESCRIPTION
A bug meant that the passed argument to Region.from_file was always
being treated as a string, preventing the usage of filelike objects.

This has been fixed, and a small test was provided to give coverage.