### PR TITLE
🌑 Allow get_section() to handle complete absence

### DIFF
--- a/anvil/chunk.py
+++ b/anvil/chunk.py
@@ -55,7 +55,13 @@ class Chunk:
         """
         if y < 0 or y > 15:
             raise ValueError('Y index must be in the range of 0 to 15')
-        for section in self.data['Sections']:
+
+        try:
+            sections = self.data["Sections"]
+        except KeyError:
+            return None
+
+        for section in sections:
             if section['Y'].value == y:
                 return section
 


### PR DESCRIPTION
In real world chunks, occasionally there will be the complete absence of
the 'Sections' tag in the NBT dictionary, and this would throw a
KeyError.

If this happens, return None, since there are clearly no sections
whatsoever.