### PR TITLE
💨 Change empty section behaviour when streaming

### DIFF
--- a/anvil/chunk.py
+++ b/anvil/chunk.py
@@ -110,7 +110,8 @@ class Chunk:
 
         # If its an empty section its most likely an air block 
         if section is None or section.get('BlockStates') is None:
-            return Block.from_name('minecraft:air')
+            for i in range(4096):
+                yield Block.from_name("minecraft:air")
 
         # Number of bits each block is on BlockStates
         # Cannot be lower than 4


### PR DESCRIPTION
An empty section is composed of 4096 blocks of air, so if stream_blocks
is given an empty section either directly or by section y-index, it
returns all air, rather than raising StopIteration, which is what
`return` does inside generators.