### PR TITLE
Added required installs to the setup.py script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,8 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],
+    install_requires=[
+        'nbt',
+        'frozendict',
+    ]
 )


### PR DESCRIPTION
When I downloaded anvil, the requirements (nbt and frozendict) didn't automatically download. I see they're in 'requirements.txt' but it appears that doesn't carry over to pypi pip install. A quick Google search appeared to resolve the issue.