### PR TITLE
💀 Revert "💨 Change empty section behaviour when streaming"

### DIFF
--- a/anvil/chunk.py
+++ b/anvil/chunk.py
@@ -193,7 +193,9 @@ class Chunk:
             section = self.get_section(section or 0)
 
         if section is None or section.get('BlockStates') is None:
-            return Block.from_name('minecraft:air')
+            air = Block.from_name('minecraft:air')
+            for i in range(4096):
+                yield air
 
         states = section['BlockStates'].value
         palette = section['Palette']

--- a/anvil/chunk.py
+++ b/anvil/chunk.py
@@ -116,8 +116,7 @@ class Chunk:
 
         # If its an empty section its most likely an air block 
         if section is None or section.get('BlockStates') is None:
-            for i in range(4096):
-                yield Block.from_name("minecraft:air")
+            return Block.from_name('minecraft:air')
 
         # Number of bits each block is on BlockStates
         # Cannot be lower than 4


### PR DESCRIPTION
Reverts matcool/anvil-parser#6

Reading through the file as a whole, I realise that this was applied to incorrect function.

These changes should be applied to https://github.com/matcool/anvil-parser/blob/master/anvil/chunk.py#L196 and not where they were.

Returning a single block of air is correct, my bad.